### PR TITLE
feat(user): Add User entity, repository, and DTOs

### DIFF
--- a/src/main/java/com/N1/sharekit/domain/User.java
+++ b/src/main/java/com/N1/sharekit/domain/User.java
@@ -1,0 +1,50 @@
+package com.N1.sharekit.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails; // UserDetails 구현 시
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @Column(name = "uid", nullable = false, unique = true)
+    private String uid; // Firebase UID
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "student_id", unique = true)
+    private String studentId;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "role")
+    private String role; // 관리자 권한 세부 구현하기
+
+    @Builder
+    public User(String uid, String email, String name, String studentId, String password, String role) {
+        this.uid = uid;
+        this.email = email;
+        this.name = name;
+        this.studentId = studentId;
+        this.password = password;
+        this.role = (role == null) ? "ROLE_PRE_AUTH_USER" : role;
+    }
+}

--- a/src/main/java/com/N1/sharekit/repository/UserRepository.java
+++ b/src/main/java/com/N1/sharekit/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.N1.sharekit.repository;
+
+import com.N1.sharekit.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/// 사용자 정보를 위한 JPA Repository
+public interface UserRepository extends JpaRepository<User, String> {
+    Optional<User> findByStudentId(String studentId);
+}

--- a/src/main/java/com/niceone/sharekit/domain/User.java
+++ b/src/main/java/com/niceone/sharekit/domain/User.java
@@ -1,4 +1,4 @@
-package com.N1.sharekit.domain;
+package com.niceone.sharekit.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/src/main/java/com/niceone/sharekit/dto/LocalLoginRequest.java
+++ b/src/main/java/com/niceone/sharekit/dto/LocalLoginRequest.java
@@ -1,0 +1,11 @@
+package com.niceone.sharekit.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LocalLoginRequest {
+    private String studentId;
+    private String password;
+}

--- a/src/main/java/com/niceone/sharekit/dto/SignupRequest.java
+++ b/src/main/java/com/niceone/sharekit/dto/SignupRequest.java
@@ -1,0 +1,12 @@
+package com.niceone.sharekit.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SignupRequest {
+    private String idToken;
+}

--- a/src/main/java/com/niceone/sharekit/dto/UserProfileRequest.java
+++ b/src/main/java/com/niceone/sharekit/dto/UserProfileRequest.java
@@ -1,0 +1,12 @@
+package com.niceone.sharekit.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserProfileRequest {
+    private String name;
+    private String studentId;
+    private String password;
+}

--- a/src/main/java/com/niceone/sharekit/dto/UserResponse.java
+++ b/src/main/java/com/niceone/sharekit/dto/UserResponse.java
@@ -1,0 +1,19 @@
+package com.niceone.sharekit.dto;
+
+import com.niceone.sharekit.domain.User;
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+    private String uid;
+    private String email;
+    private String name;
+    private String studentId;
+
+    public UserResponse(User user) {
+        this.uid = user.getUid();
+        this.email = user.getEmail();
+        this.name = user.getName();
+        this.studentId = user.getStudentId();
+    }
+}

--- a/src/main/java/com/niceone/sharekit/repository/UserRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.N1.sharekit.repository;
+package com.niceone.sharekit.repository;
 
-import com.N1.sharekit.domain.User;
+import com.niceone.sharekit.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;


### PR DESCRIPTION
## 작업 목표
- 사용자 인증 및 프로필 관리에 필요한 핵심 엔티티, 데이터 접근을 위한 레포지토리, 그리고 클라이언트 통신에 사용될 DTO의 정의

## 주요 변경 사항
* **User 엔티티 및 레포지토리**
    * JPA를 사용하여 데이터베이스와 매핑될 `User` 엔티티를 정의
    * Spring Data JPA를 확장하여 데이터 영속성을 관리하는 `UserRepository` 인터페이스를 생성

* **데이터 전송 객체 (DTOs)**
    * `LocalLoginRequest`: 로컬 로그인 요청 처리를 위한 DTO
    * `SignupRequest`: 회원가입 요청 처리를 위한 DTO
    * `UserProfileRequest`: 사용자 프로필 수정 요청을 위한 DTO
    * `UserResponse`: 클라이언트에 사용자 데이터를 응답하기 위한 DTO

## 기타 사항
- 실수로 생성되었던 불필요한 파일(equipment-entity)은 이번 변경 사항에서 제외했습니다.