### PR TITLE
feat(security): Configure Spring Security and token authentication filters

### DIFF
--- a/src/main/java/com/niceone/sharekit/config/FirebaseTokenFilter.java
+++ b/src/main/java/com/niceone/sharekit/config/FirebaseTokenFilter.java
@@ -1,0 +1,88 @@
+package com.niceone.sharekit.config;
+
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.niceone.sharekit.service.FirebaseService;
+import com.niceone.sharekit.domain.user.User;
+import com.niceone.sharekit.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/// Firebase 토큰 검사 필터
+@RequiredArgsConstructor
+@Component
+public class FirebaseTokenFilter extends OncePerRequestFilter {
+
+    private final FirebaseService firebaseService;
+    private final UserService userService;
+    private static final Logger logger = Logger.getLogger(FirebaseTokenFilter.class.getName());
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String idToken = header.substring(7);
+
+        try {
+            // firebase id 토큰 검증
+            FirebaseToken decodedToken = firebaseService.verifyToken(idToken);
+            String uid = decodedToken.getUid();
+
+            // db에서 사용자 정보 조회
+            Optional<User> optionalUser = userService.findByUid(uid);
+
+            if (optionalUser.isPresent()) {
+                User user = optionalUser.get();
+                Collection<GrantedAuthority> authorities = new ArrayList<>();
+                if (user.getRole() != null && !user.getRole().isEmpty()) {
+                    authorities.add(new SimpleGrantedAuthority(user.getRole()));
+                } else {
+                    authorities.add(new SimpleGrantedAuthority("ROLE_PRE_AUTH_USER"));
+                }
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(user, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+        } catch (FirebaseAuthException e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid firebase token: " + e.getMessage());
+            logger.severe("Firebase token validation failed: " + e.getMessage());
+            return;
+        } catch (NoSuchElementException e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "User not found in database: " + e.getMessage());
+            logger.severe("User not found: " + e.getMessage());
+            return;
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication error: " + e.getMessage());
+            logger.severe("Authentication error: " + e.getMessage());
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/niceone/sharekit/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/niceone/sharekit/config/JwtAuthenticationFilter.java
@@ -1,0 +1,121 @@
+package com.niceone.sharekit.config;
+
+import com.niceone.sharekit.domain.User;
+import com.niceone.sharekit.service.JwtTokenProvider;
+import com.niceone.sharekit.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String jwt = resolveToken(request);
+
+        if (StringUtils.hasText(jwt)) {
+            try {
+                if (jwtTokenProvider.validateToken(jwt)) {
+                    String uid = jwtTokenProvider.getUidFromToken(jwt);
+
+                    User user = userService.findByUid(uid)
+                            .orElseThrow(() -> new UsernameNotFoundException("User not found with UID: " + uid + " from JWT."));
+
+                    if (user.getStudentId() == null || user.getStudentId().isEmpty() ||
+                            user.getPassword() == null || user.getPassword().isEmpty()) {
+                        log.warn("JWT authentication attempt for user UID: {} who has not completed profile setup (studentId or password missing).", uid);
+                    }
+
+                    Collection<? extends GrantedAuthority> authorities;
+                    if (user.getRole() != null && !user.getRole().isEmpty()) {
+                        authorities = Arrays.stream(user.getRole().split(","))
+                                .map(SimpleGrantedAuthority::new)
+                                .collect(Collectors.toList());
+                    } else {
+                        authorities = new ArrayList<>();
+                    }
+
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(user, null, authorities);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("JWT authentication successful for user UID: {}, authorities: {}", uid, authorities);
+                } else {
+                    log.warn("Invalid JWT token provided.");
+                }
+            } catch (UsernameNotFoundException e) {
+                log.warn("JWT authentication failed: User not found. {}", e.getMessage());
+                SecurityContextHolder.clearContext();
+            } catch (ExpiredJwtException e) {
+                log.warn("JWT authentication failed: Token expired. {}", e.getMessage());
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"error\": \"Token expired\", \"message\": \"" + e.getMessage() + "\"}");
+                response.setContentType("application/json");
+                return;
+            } catch (SignatureException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+                log.warn("JWT authentication failed: Invalid token. {}", e.getMessage());
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"error\": \"Invalid token\", \"message\": \"" + e.getMessage() + "\"}");
+                response.setContentType("application/json");
+                return;
+            } catch (Exception e) {
+                log.error("JWT authentication failed with unexpected error.", e);
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                response.getWriter().write("{\"error\": \"Authentication error\", \"message\": \"" + e.getMessage() + "\"}");
+                response.setContentType("application/json");
+                return;
+            }
+        } else {
+            log.trace("No JWT token found in request header.");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * HttpServletRequest 에서 Authorization 헤더를 가로채서 Bearer 토큰을 추출
+     * @param request HttpServletRequest 객체
+     * @return 추출된 JWT 문자열 또는 null
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
+++ b/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.niceone.sharekit.config;
+
+public class SecurityConfig {
+}

--- a/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
+++ b/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
@@ -1,4 +1,82 @@
 package com.niceone.sharekit.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final FirebaseTokenFilter firebaseTokenFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(firebaseTokenFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // SecurityConfig.java (authorizeHttpRequests 부분)
+                .authorizeHttpRequests(authz -> authz
+                        // 1. 인증 없이 접근 허용
+                        .requestMatchers(
+                                PathRequest.toStaticResources().atCommonLocations(),
+
+                                // 정적 리소스 (css, js, images)
+                                AntPathRequestMatcher.antMatcher("/js/**"),
+                                AntPathRequestMatcher.antMatcher("/css/**"),
+                                AntPathRequestMatcher.antMatcher("/images/**"),
+                                // HTML 페이지 경로 (GET 요청)
+                                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/"),
+                                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/login"),
+                                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/signup"),
+                                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/profile"),
+                                AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/equipment-list"),
+                                // API 인증/인가 관련 경로
+                                AntPathRequestMatcher.antMatcher("/api/auth/signup"),
+                                AntPathRequestMatcher.antMatcher("/api/auth/login"),
+                                // 기타 공개 경로
+                                AntPathRequestMatcher.antMatcher("/public/**"),
+                                AntPathRequestMatcher.antMatcher("/error"),
+                                AntPathRequestMatcher.antMatcher("/favicon.ico"),
+                                AntPathRequestMatcher.antMatcher("/v3/api-docs/**"),
+                                AntPathRequestMatcher.antMatcher("/swagger-ui/**"),
+                                AntPathRequestMatcher.antMatcher("/swagger-resources/**")
+                        ).permitAll()
+
+                        // 2. Firebase 토큰 인증 필요한 경로
+                        .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.PUT, "/api/users/me/profile"))
+                        .hasAnyAuthority("ROLE_PRE_AUTH_USER", "ROLE_USER", "ROLE_ADMIN")
+
+                        // 3. JWT 인증 필요한 API 경로들
+                        .requestMatchers(AntPathRequestMatcher.antMatcher("/api/**"))
+                        .hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
+
+                        // 4. 지정되지 않은 나머지 요청은 인증 요구
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }


### PR DESCRIPTION
## 작업 목표
- Spring Security를 적용하여 API 엔드포인트 보안 강화
- JWT 및 Firebase 토큰을 검증하는 인증 필터 구현

## 주요 변경 사항
- **Spring Security 기본 설정 (`SecurityConfig.java`)**
  - `HttpSecurity`를 통한 인증/인가 규칙 및 경로 설정
  - `JwtAuthenticationFilter` 및 `FirebaseTokenFilter`를 필터 체인에 등록

- **인증 필터 구현**
  - 자체 발급 JWT 검증을 위한 `JwtAuthenticationFilter`를 구현했습니다.
  - Firebase ID 토큰 검증을 위한 `FirebaseTokenFilter`를 구현했습니다.

## 참고사항
- 인증이 필요 없는 경로(`permitAll`)로 `/api/auth/**` 등을 설정했습니다. 추가/수정이 필요한 경로가 있는지 리뷰 부탁드립니다.