### PR TITLE
feat(domain): Define Equipment entity and Equipment Status Enum

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
@@ -1,0 +1,55 @@
+package com.niceone.sharekit.domain.equipment;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "equipment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+
+public class Equipment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String itemIdentifier;
+
+    @Column(nullable = false, length = 100)
+    private String typeName; 
+
+    @Column(length = 255)
+    private String imageUrl; 
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private EquipmentStatus status; 
+
+    @Column(length = 500)
+    private String additionalInfo; 
+
+
+    // Rental 엔티티와의 1:N 관계: 하나의 장비는 여러 대여 기록을 가질 수 있음
+    // 'mappedBy = "equipment"'는 Rental 엔티티 내에 있는 'equipment' 필드에 의해 관계가 관리됨.
+    @OneToMany(mappedBy = "equipment", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Rental> rentals = new ArrayList<>();
+
+    public void addRental(Rental rental) {
+    this.rentals.add(rental); // 현재 Equipment의 rentals 목록에 rental 추가
+    if (rental.getEquipment() != this) { // 무한루프 방지 및 중복 호출 방지 로직
+        rental.setEquipment(this);
+    }   
+}

--- a/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
@@ -1,0 +1,8 @@
+package com.niceone.sharekit.domain.equipment;
+
+public enum EquipmentStatus {
+    AVAILABLE,  // 대여 가능
+    RENTED,     // 대여 중 
+    IN_REPAIR,  // 수리 중
+    UNAVAILABLE // 대여 불가(게타 사유유)
+}


### PR DESCRIPTION
## 작업 목표
- 장비 관련 기본 데이터 모델을 정의
-  향후 장비 등록, 상태 관리, 대여 및 반납 기능 구현의 기반 마련

## 주요 변경 사항
- `EquipmentStatus.java`: 장비의 상태(대여 가능, 대여 중, 수리 중, 사용 불가)를 나타내는 Enum 클래스 정의
- `Equipment.java`: 개별 장비 아이템 및 장비 종류 정보를 통합적으로 관리하는 단일 엔티티 클래스를 정의
- `Rental` 엔티티와의 1:N 관계를 설정하여, 하나의 장비에 여러 대여 이력이 연결될 수 있도록 준비

## 참고사항
- 본 PR은 엔티티 클래스 정의에 중점을 두었습니다. 관련된 Repository 및 Service 로직, 상세 DTO 등은 후속 작업 및 PR을 통해 다룰 예정입니다.
- `Rental` 엔티티는 아직 정의되지 않았으므로, `Equipment.java` 내 `Rental` 관련 import 문 및 필드 타입은 `Rental` 엔티티 구현 시 최종적으로 확인 및 수정될 수 있습니다.