### PR TITLE
feat(controller): Implement API and UI page controllers

### DIFF
--- a/src/main/java/com/niceone/sharekit/controller/AuthController.java
+++ b/src/main/java/com/niceone/sharekit/controller/AuthController.java
@@ -1,0 +1,102 @@
+package com.niceone.sharekit.controller;
+
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.niceone.sharekit.domain.User;
+import com.niceone.sharekit.dto.LocalLoginRequest;
+import com.niceone.sharekit.dto.SignupRequest;
+import com.niceone.sharekit.dto.UserResponse;
+import com.niceone.sharekit.service.FirebaseService;
+import com.niceone.sharekit.service.JwtTokenProvider;
+import com.niceone.sharekit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final FirebaseService firebaseService;
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    /// 학번과 비밀번호로 로컬 로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@RequestBody LocalLoginRequest loginRequest) {
+        log.info("Attempting login with student ID: {}", loginRequest.getStudentId());
+
+        Optional<User> userOptional = userService.findByStudentId(loginRequest.getStudentId());
+
+        if (userOptional.isEmpty()) {
+            log.warn("Login failed: User not found with student ID: {}", loginRequest.getStudentId());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "학번 또는 비밀번호가 일치하지 않습니다."));
+        }
+
+        User user = userOptional.get();
+
+        if (user.getPassword() == null || !passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            log.warn("Login failed: Password mismatch for student ID: {}", loginRequest.getStudentId());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "학번 또는 비밀번호가 일치하지 않습니다."));
+        }
+
+        // 비밀번호 일치 시 JWT 생성
+        final String jwt = jwtTokenProvider.generateToken(user);
+
+        log.info("User logged in successfully with student ID: {}", loginRequest.getStudentId());
+
+        return ResponseEntity.ok(Map.of(
+                "accessToken", jwt,
+                "user", new UserResponse(user)
+        ));
+    }
+
+
+    /// Firebase 기반 회원 가입
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody SignupRequest signupRequest) {
+        try {
+            FirebaseToken decodedToken = firebaseService.verifyToken(signupRequest.getIdToken());
+            String uid = decodedToken.getUid();
+            String email = decodedToken.getEmail();
+
+            if (userService.findByUid(uid).isPresent()) {
+                log.warn("Attempted signup for already existing user: {}", email);
+                return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 가입된 사용자입니다. 로그인해주세요.");
+            }
+
+            User newUser = User.builder()
+                    .uid(uid)
+                    .email(email)
+                    .name(decodedToken.getName())
+                    .build();
+
+            userService.registerNewUser(newUser);
+
+            log.info("New user signed up: {}", email);
+            return ResponseEntity.ok("회원가입 완료. 프로필 정보를 입력해주세요.");
+
+        } catch (FirebaseAuthException e) {
+            log.error("Invalid Firebase Token during signup: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다.", e);
+        } catch (Exception e) {
+            log.error("Signup failed for token: {}", signupRequest.getIdToken(), e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 처리 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/niceone/sharekit/controller/MainController.java
+++ b/src/main/java/com/niceone/sharekit/controller/MainController.java
@@ -1,0 +1,36 @@
+package com.niceone.sharekit.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@Controller
+@RequiredArgsConstructor
+public class MainController {
+
+    @GetMapping("/")
+    public String mainPage() {
+        return "main";
+    }
+
+    @GetMapping("/login")
+    public String loginPage() {
+        return "login";
+    }
+
+    @GetMapping("/signup")
+    public String signupPage() {
+        return "signup";
+    }
+
+    @GetMapping("/profile")
+    public String memberInfoPage() {
+        return "profile";
+    }
+
+    @GetMapping("/equipment-list")
+    public String equipmentListPage() {
+        return "equipment-list";
+    }
+}

--- a/src/main/java/com/niceone/sharekit/controller/UserController.java
+++ b/src/main/java/com/niceone/sharekit/controller/UserController.java
@@ -1,0 +1,45 @@
+package com.niceone.sharekit.controller;
+
+import com.niceone.sharekit.domain.User;
+import com.niceone.sharekit.dto.UserProfileRequest;
+import com.niceone.sharekit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /// signup 에서 인증 받은 사용자의 프로필 업데이트
+    @PutMapping("/me/profile")
+    public ResponseEntity<String> updateProfile(
+            @AuthenticationPrincipal User authenticatedUser,
+            @RequestBody UserProfileRequest profileRequest) {
+
+        if (authenticatedUser == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증된 사용자 정보를 찾을 수 없습니다.");
+        }
+
+        String uid = authenticatedUser.getUid();
+
+        try {
+            userService.updateUserProfile(uid, profileRequest);
+
+            log.info("User profile updated successfully for user UID: {}", uid);
+            return ResponseEntity.ok("프로필 정보가 성공적으로 업데이트되었습니다.");
+
+        } catch (Exception e) {
+            log.error("Failed to update profile for user UID: {}", uid, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 업데이트 중 오류가 발생했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 목표
- 사용자 인증(회원가입, 로그인)을 위한 API 컨트롤러 구현
- 사용자 프로필 관리를 위한 API 컨트롤러 구현
- 기본 정적 UI 페이지 라우팅을 위한 컨트롤러 구현

## 주요 변경 사항
- **`AuthController.java`**: 회원가입 및 로그인 API 엔드포인트를 제공
- **`UserController.java`**: 사용자 프로필 조회, 수정 등 관련 API 엔드포인트를 제공
- **`MainController.java`** 메인, 로그인, 회원가입, 프로필, 장비 목록 등 정적 UI 페이지로의 라우팅 처리

## 참고사항
- `AuthController` 및 `UserController`의 API는 이전에 설정된 Spring Security 및 JWT/Firebase 인증 필터의 보호를 받습니다. 관련 보안 설정을 함께 고려하여 리뷰해주시면 좋겠습니다.