### PR TITLE
feat(domain): Define Rental entity and Rental Status Enum

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/rental/Rental.java
+++ b/src/main/java/com/niceone/sharekit/domain/rental/Rental.java
@@ -1,0 +1,46 @@
+package com.niceone.sharekit.domain.rental;
+
+import com.niceone.sharekit.domain.User; // User 엔티티의 실제 패키지 경로로 수정해주세요.
+import com.niceone.sharekit.domain.equipment.Equipment; // 우리가 정의한 단일 Equipment 엔티티
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "rental")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Rental {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 대여 사용자 (User와 N:1 관계)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "equipment_id", nullable = false)
+    private Equipment equipment; // 대여 장비 (Equipment 엔티티와 N:1 관계)
+
+    @Column(nullable = false)
+    private LocalDateTime rentalDate; // 대여일시
+
+    @Column(nullable = false)
+    private LocalDateTime dueDate; // 반납 예정일시
+
+    private LocalDateTime returnDate; // 실제 반납일시 (nullable)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private RentalStatus status; // 대여 상태 (Enum: RENTED, RETURNED, OVERDUE 등)
+
+}

--- a/src/main/java/com/niceone/sharekit/domain/rental/RentalStatus.java
+++ b/src/main/java/com/niceone/sharekit/domain/rental/RentalStatus.java
@@ -1,0 +1,7 @@
+package com.niceone.sharekit.domain.rental;
+
+public enum RentalStatus {
+    RENTED,   //대여 중
+    RETURNED, // 반납 완료
+    OVERDUE   // 연체 중
+}


### PR DESCRIPTION
## 작업 목표
장비 대여 및 반납 기록을 관리하기 위한 핵심 데이터 모델인 `Rental` 엔티티와 관련 상태(`RentalStatus`) 정의

## 주요 변경 사항
- `RentalStatus.java`: 대여 상태(`RENTED`, `RETURNED`, `OVERDUE`)를 나타내는 Enum 클래스를 정의
- `Rental.java`: 실제 대여 기록을 나타내는 엔티티 클래스를 정의했으며, `User` 및 `Equipment` 엔티티와 N:1 연관관계를 설정
- 주요 필드: `id`, `user`, `equipment`, `rentalDate`, `dueDate`, `returnDate`, `status`.

## 참고사항
- 관련된 `RentalRepository`, DTO 및 서비스 로직은 후속 작업 및 PR을 통해 다룰 예정입니다.
- `User` 및 `Equipment` 엔티티는 `develop` 브랜치에 이미 정의되어 있음을 전제로 하며, 본 PR에서 해당 엔티티들을 참조합니다.