### PR TITLE
feat(equipment): Enhance Equipment entity and repository with location and fixes

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
@@ -4,5 +4,5 @@ public enum EquipmentStatus {
     AVAILABLE,  // 대여 가능
     RENTED,     // 대여 중 
     IN_REPAIR,  // 수리 중
-    UNAVAILABLE // 대여 불가(게타 사유유)
+    UNAVAILABLE // 대여 불가(기타 사유)
 }

--- a/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
@@ -1,0 +1,35 @@
+package com.niceone.sharekit.repository;
+
+import com.niceone.sharekit.domain.equipment.Equipment;
+import com.niceone.sharekit.domain.equipment.EquipmentStatus;
+import jakarta.persistence.LockModeType; // LockModeType 임포트 추가됨 (좋음)
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;     // @Lock 임포트 추가됨 (좋음)
+import org.springframework.data.jpa.repository.Query;    // @Query 임포트 추가됨 (좋음)
+import org.springframework.data.repository.query.Param;  // @Param 임포트 추가됨 (좋음)
+import java.util.List;
+import java.util.Optional;
+
+public interface EquipmentRepository extends JpaRepository<Equipment, Long> {
+
+    // 개별 장비 식별자로 조회
+    Optional<Equipment> findByItemIdentifier(String itemIdentifier);
+
+    // 장비 분류명으로 조회
+    List<Equipment> findByTypeName(String typeName);
+
+    // 장비 상태로 조회
+    List<Equipment> findByStatus(EquipmentStatus status);
+
+    // 장비 분류명과 상태로 조회
+    List<Equipment> findByTypeNameAndStatus(String typeName, EquipmentStatus status);
+
+    // 장비 분류명(typeName)에 특정 문자열을 포함하는 장비 검색 (부분 문자열 검색)
+    List<Equipment> findByTypeNameContaining(String keyword);
+
+    // 동시성 제어를 위한 비관적 쓰기 잠금을 사용하는 조회 메소드
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Equipment e WHERE e.itemIdentifier = :itemIdentifier")
+    Optional<Equipment> findByItemIdentifierForUpdate(@Param("itemIdentifier") String itemIdentifier);
+
+}


### PR DESCRIPTION
## 작업 목표
- Equipment 엔티티에 대여 가능 장소 및 시간 정보를 추가
- EquipmentRepository에 누락된 쿼리 메소드 추가 및 관련 파일들의 오타 수정

## 주요 변경 사항
1.  Equipment.java :
    - `rentalLocation` (대여 가능 장소) 필드를 추가했습니다.
    - `Rental` 엔티티 참조를 위한 `import` 경로를 확인 및 수정했습니다.
2.  EquipmentStatus.java :
    - 발견된 오타를 수정했습니다. 
3.  EquipmentRepository.java :
    - 누락되었던 주요 커스텀 쿼리 메소드들을 추가했습니다:
        - `findByItemIdentifier`
        - `findByTypeName`
        - `findByStatus`
        - `findByTypeNameAndStatus`
        - `findByTypeNameContaining`
        - `findByItemIdentifierForUpdate` (동시성 제어용)

## 참고사항.
- 이 변경 사항들은 향후 장비 조회, 관리 및 대여 기능 구현에 활용될 예정입니다.
- 데이터베이스 스키마 변경이 수반될 수 있습니다.