### PR TITLE
feat(equipment): Enhance Equipment entity and repository

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
@@ -1,8 +1,8 @@
 package com.niceone.sharekit.domain.equipment;
 
+import com.niceone.sharekit.domain.rental.Rental;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.AccessLevel;
@@ -17,7 +17,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-
 public class Equipment {
 
     @Id
@@ -25,31 +24,41 @@ public class Equipment {
     private Long id;
 
     @Column(nullable = false, unique = true, length = 50)
-    private String itemIdentifier;
+    private String itemIdentifier; // 개별 장비 식별자
+
+    @Column(nullable = false, length = 150)
+    private String name; // 장비의 구체적인 이름 또는 모델명
 
     @Column(nullable = false, length = 100)
-    private String typeName; 
+    private String typeName; // 장비의 종류/분류
 
     @Column(length = 255)
-    private String imageUrl; 
+    private String imageUrl; // 이미지 URL
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    private EquipmentStatus status; 
+    private EquipmentStatus status; // 장비 상태
+
+    @Column(length = 200)
+    private String rentalLocation; // 대여 가능 장소
+
+    @Column(length = 255) // << "대여 가능 시간 정보" 필드 추가!
+    private String availableTimeInfo; // 예: "평일 09:00-18:00", "상시 가능"
+
+    @Column(length = 1000)
+    private String description; // 장비에 대한 상세 설명
 
     @Column(length = 500)
-    private String additionalInfo; 
+    private String additionalInfo; // 기타 추가 정보
 
-
-    // Rental 엔티티와의 1:N 관계: 하나의 장비는 여러 대여 기록을 가질 수 있음
-    // 'mappedBy = "equipment"'는 Rental 엔티티 내에 있는 'equipment' 필드에 의해 관계가 관리됨.
     @OneToMany(mappedBy = "equipment", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Rental> rentals = new ArrayList<>();
 
     public void addRental(Rental rental) {
-    this.rentals.add(rental); // 현재 Equipment의 rentals 목록에 rental 추가
-    if (rental.getEquipment() != this) { // 무한루프 방지 및 중복 호출 방지 로직
-        rental.setEquipment(this);
-    }   
+        this.rentals.add(rental);
+        if (rental.getEquipment() != this) {
+            rental.setEquipment(this);
+        }
+    }
 }

--- a/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatus.java
@@ -4,5 +4,5 @@ public enum EquipmentStatus {
     AVAILABLE,  // 대여 가능
     RENTED,     // 대여 중 
     IN_REPAIR,  // 수리 중
-    UNAVAILABLE // 대여 불가(게타 사유유)
+    UNAVAILABLE // 대여 불가(기타 사유)
 }

--- a/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
@@ -1,5 +1,36 @@
 package com.niceone.sharekit.repository;
 
-public class EquipmentRepository {
+import com.niceone.sharekit.domain.equipment.Equipment;
+import com.niceone.sharekit.domain.equipment.EquipmentStatus;
+import jakarta.persistence.LockModeType; 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;     
+import org.springframework.data.jpa.repository.Query;    
+import org.springframework.data.repository.query.Param;  
+import java.util.List;
+import java.util.Optional;
+
+public interface EquipmentRepository extends JpaRepository<Equipment, Long> {
+
+    // 개별 장비 식별자로 조회
+    Optional<Equipment> findByItemIdentifier(String itemIdentifier);
+
+    // 장비 분류명으로 조회
+    List<Equipment> findByTypeName(String typeName);
+
+    // 장비 상태로 조회
+    List<Equipment> findByStatus(EquipmentStatus status);
+
+    // 장비 분류명과 상태로 조회
+    List<Equipment> findByTypeNameAndStatus(String typeName, EquipmentStatus status);
+
+    // 장비 분류명(typeName)에 특정 문자열을 포함하는 장비 검색 (부분 문자열 검색)
+    List<Equipment> findByTypeNameContaining(String keyword);
+
+    // 동시성 제어를 위한 비관적 쓰기 잠금을 사용하는 조회 메소드
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Equipment e WHERE e.itemIdentifier = :itemIdentifier")
+    Optional<Equipment> findByItemIdentifierForUpdate(@Param("itemIdentifier") String itemIdentifier);
 
 }
+


### PR DESCRIPTION
## 작업 배경

- 기존에 진행하던 장비 관련 기능 추가 작업에서 충돌 문제가 발생하였고 커밋 명명 규칙 이탈 커밋이 존재하여 해당 PR을 닫고 새로운 브랜치에서 재구성하였습니다.

## 주요 작업 내용

- 장비의 대여 위치를 추적하기 위한 rentalLocation필드를 Equipment 엔티티에 추가 (`cherry-pick`으로 적용)
- EquipmentRepository`에 누락된 쿼리 메서드 추가 및 충돌 해결

## 참고 사항 

- 이 PR이 병합되면 이전에 닫았던 `feature/equipment-entity` 및 `bugfix/equipment-entity` 브랜치는 삭제하도록 하겠습니다.
- 데이터베이스 스키마 변경이 수반될 수 있습니다.

Close #[15]