### PR TITLE
feat(user): User/Role 다대다 관계 적용 및 서비스 로직 수정

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/user/User.java
+++ b/src/main/java/com/niceone/sharekit/domain/user/User.java
@@ -1,11 +1,16 @@
 package com.niceone.sharekit.domain.user;
 
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
+import java.util.HashSet;
+import java.util.Set;
+import jakarta.persistence.*;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
 
 @Getter
 @Setter
@@ -30,16 +35,20 @@ public class User {
     @Column(name = "password")
     private String password;
 
-    @Column(name = "role")
-    private String role; // 관리자 권한 세부 구현하기
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "user_roles", // 중간 테이블
+            joinColumns = @JoinColumn(name = "user_uid"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
 
     @Builder
-    public User(String uid, String email, String name, String studentId, String password, String role) {
+    public User(String uid, String email, String name, String studentId, String password) {
         this.uid = uid;
         this.email = email;
         this.name = name;
         this.studentId = studentId;
         this.password = password;
-        this.role = (role == null) ? "ROLE_PRE_AUTH_USER" : role;
     }
 }

--- a/src/main/java/com/niceone/sharekit/service/UserService.java
+++ b/src/main/java/com/niceone/sharekit/service/UserService.java
@@ -36,8 +36,14 @@ public class UserService {
 
     @Transactional
     public void registerNewUser(User user) {
-        // TODO: 여기에 "ROLE_PRE_AUTH_USER" 역할 할당 로직 추가 예정
+        Role preAuthUserRole = roleRepository.findByName("ROLE_PRE_AUTH_USER")
+                .orElseThrow(() -> {
+                    log.error("'ROLE_PRE_AUTH_USER' not found in database. Check DataInitializer.");
+                    return new IllegalStateException("'ROLE_PRE_AUTH_USER' not found. This is a server configuration issue.");
+                });
+        user.getRoles().add(preAuthUserRole);
         userRepository.save(user);
+        log.info("New user registered with UID: {} and granted ROLE_PRE_AUTH_USER", user.getUid());
     }
 
     @Transactional

--- a/src/main/java/com/niceone/sharekit/service/UserService.java
+++ b/src/main/java/com/niceone/sharekit/service/UserService.java
@@ -59,9 +59,29 @@ public class UserService {
         if (request.getPassword() != null && !request.getPassword().trim().isEmpty()) {
             user.setPassword(passwordEncoder.encode(request.getPassword()));
         }
-        // TODO: 여기에 "ROLE_USER" 역할 할당 및 "ROLE_PRE_AUTH_USER" 역할 제거 로직 추가 예정
+
+        Role userRole = roleRepository.findByName("ROLE_USER")
+                .orElseThrow(() -> {
+                    log.error("'ROLE_USER' not found in database. Check DataInitializer.");
+                    return new IllegalStateException("'ROLE_USER' not found. This is a server configuration issue.");
+                });
+        user.getRoles().add(userRole);
+        log.info("Role 'ROLE_USER' added to user UID: {}", uid);
+
+        Optional<Role> preAuthUserRoleOptional = roleRepository.findByName("ROLE_PRE_AUTH_USER");
+        if (preAuthUserRoleOptional.isPresent()) {
+            if (user.getRoles().contains(preAuthUserRoleOptional.get())) {
+                user.getRoles().remove(preAuthUserRoleOptional.get());
+                log.info("Role 'ROLE_PRE_AUTH_USER' removed from user UID: {}", uid);
+            } else {
+                log.info("User UID: {} did not have 'ROLE_PRE_AUTH_USER' to remove.", uid);
+            }
+        } else {
+            log.warn("'ROLE_PRE_AUTH_USER' not found in database for removal. Check DataInitializer.");
+        }
+
         userRepository.save(user);
-        log.info("User UID: {} profile updated. Role update logic needs to be revised for Set<Role>.", uid);
+        log.info("User UID: {} profile updated. profile updated successfully. Roles adjusted.", uid);
 
     }
 

--- a/src/main/java/com/niceone/sharekit/service/UserService.java
+++ b/src/main/java/com/niceone/sharekit/service/UserService.java
@@ -1,7 +1,9 @@
 package com.niceone.sharekit.service;
 
+import com.niceone.sharekit.domain.user.Role;
 import com.niceone.sharekit.domain.user.User;
 import com.niceone.sharekit.dto.UserProfileRequest;
+import com.niceone.sharekit.repository.RoleRepository;
 import com.niceone.sharekit.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -12,6 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
+import java.util.Set;
 
 /// 사용자 중복 방지 및 정보 조회/저장
 @Slf4j
@@ -20,14 +23,20 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RoleRepository roleRepository;
 
-    public UserService(UserRepository userRepository, @Lazy PasswordEncoder passwordEncoder) {
+    // 생성자 수정
+    public UserService(UserRepository userRepository,
+                       @Lazy PasswordEncoder passwordEncoder,
+                       RoleRepository roleRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.roleRepository = roleRepository;
     }
 
     @Transactional
     public void registerNewUser(User user) {
+        // TODO: 여기에 "ROLE_PRE_AUTH_USER" 역할 할당 로직 추가 예정
         userRepository.save(user);
     }
 
@@ -35,6 +44,7 @@ public class UserService {
     public void updateUserProfile(String uid, UserProfileRequest request) {
         User user = userRepository.findById(uid)
                 .orElseThrow(() -> {
+                    log.error("User not found with UID: {}", uid);
                     return new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found with UID: " + uid);
                 });
 
@@ -43,9 +53,9 @@ public class UserService {
         if (request.getPassword() != null && !request.getPassword().trim().isEmpty()) {
             user.setPassword(passwordEncoder.encode(request.getPassword()));
         }
-        user.setRole("ROLE_USER");
+        // TODO: 여기에 "ROLE_USER" 역할 할당 및 "ROLE_PRE_AUTH_USER" 역할 제거 로직 추가 예정
         userRepository.save(user);
-        log.info("User UID: {} role updated to ROLE_USER after profile update.", uid);
+        log.info("User UID: {} profile updated. Role update logic needs to be revised for Set<Role>.", uid);
 
     }
 


### PR DESCRIPTION
## 작업 목표
- 사용자 다중 역할 지원을 위해 기존 User 엔티티의 단일 역할 구조를 Role 엔티티와의 다대다 관계로의 재구성

## 주요 변경 사항

- **User 엔티티**: `String role` 필드를 `Set<Role>` 필드로 변경하고 다대다 관계 매핑을 적용
- **UserService**: 역할 변경에 맞춰 신규 사용자 등록 및 프로필 업데이트 시 역할(`ROLE_PRE_AUTH_USER`, `ROLE_USER`)을 할당하고 변경하는 로직을 구현

## 기타 사항

- 이 PR은 역할 관리의 모델 및 서비스 로직 기반을 마련하며, 실제 접근 제어는 후속 PR에서 `SecurityConfig` 수정을 통해 구현될 예정입니다.