### PR TITLE
feat(repository): Add RentalRepository interface

### DIFF
--- a/src/main/java/com/niceone/sharekit/repository/RentalRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/RentalRepository.java
@@ -1,0 +1,24 @@
+package com.niceone.sharekit.repository;
+
+import com.niceone.sharekit.domain.user.User;
+import com.niceone.sharekit.domain.equipment.Equipment;
+import com.niceone.sharekit.domain.rental.Rental;
+import com.niceone.sharekit.domain.rental.RentalStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RentalRepository extends JpaRepository<Rental, Long> {
+
+    // User 관련 조회
+    List<Rental> findByUserOrderByRentalDateDesc(User user);
+    List<Rental> findByUserUidOrderByRentalDateDesc(String uid);
+    List<Rental> findByUserUidAndStatus(String uid, RentalStatus status);
+
+    // Equipment 관련 조회
+    Optional<Rental> findByEquipmentAndStatusIn(Equipment equipment, List<RentalStatus> statuses);
+
+    // Rental 상태 관련 조회
+    List<Rental> findByStatus(RentalStatus status);
+}


### PR DESCRIPTION
## 작업 목표
Rental 엔티티에 대한 데이터베이스 접근 및 영속성 관리를 담당할 RentalRepository 인터페이스를 정의

## 주요 변경 사항
- RentalRepository.java 인터페이스를 신규 생성
- JpaRepository<Rental, Long>를 상속 받아 기본적인 CRUD 기능 제공
- 사용자(UID), 장비, 대여 상태 등 다양한 조건으로 대여 기록을 조회할 수 있는 커스텀 쿼리 메소드 추가

## 참고사항
- RentalRepository에 추가된 커스텀 쿼리 메소드들은 향후 RentalService에서 '내 대여 내역 조회', '특정 장비의 현재 대여 상태 확인' 등의 비즈니스 로직을 구현하는 데 사용될 예정입니다. 
- 이 리포지토리의 구체적인 활용 및 관련 DTO 구현은 후속 PR에서 다루어집니다.