### PR TITLE
feat(DTO): Define DTOs for Rental creation and response

### DIFF
--- a/src/main/java/com/niceone/sharekit/dto/rental/RentalCreateRequestDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/rental/RentalCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.niceone.sharekit.dto.rental;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RentalCreateRequestDto {
+
+    @NotBlank(message = "대여하려는 장비의 고유 식별자(itemIdentifier)는 필수입니다.")
+    private String equipmentItemIdentifier;
+
+}

--- a/src/main/java/com/niceone/sharekit/dto/rental/RentalResponseDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/rental/RentalResponseDto.java
@@ -1,0 +1,53 @@
+package com.niceone.sharekit.dto.rental;
+
+import com.niceone.sharekit.domain.rental.Rental;
+import com.niceone.sharekit.domain.rental.RentalStatus;
+import com.niceone.sharekit.dto.equipment.EquipmentResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+@NoArgsConstructor
+public class RentalResponseDto {
+
+    private Long rentalId;
+    private EquipmentResponseDto equipment; // 대여한 장비의 상세 정보
+    private RentalStatus status;
+    private LocalDateTime rentalDate;
+    private LocalDateTime dueDate;
+    private LocalDateTime returnDate;
+    private long overdueDays; // 연체 일수
+
+    public RentalResponseDto(Rental rental) {
+        this.rentalId = rental.getId();
+        this.equipment = EquipmentResponseDto.fromEntity(rental.getEquipment());
+        this.status = rental.getStatus();
+        this.rentalDate = rental.getRentalDate();
+        this.dueDate = rental.getDueDate();
+        this.returnDate = rental.getReturnDate();
+        this.overdueDays = calculateOverdueDays(rental);
+    }
+
+    public static RentalResponseDto fromEntity(Rental rental) {
+        return new RentalResponseDto(rental);
+    }
+
+    private static long calculateOverdueDays(Rental rental) {
+        if (rental.getDueDate() == null) return 0;
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime dueDate = rental.getDueDate();
+        LocalDateTime returnDate = rental.getReturnDate();
+
+        if (returnDate != null && returnDate.isAfter(dueDate)) {
+            return ChronoUnit.DAYS.between(dueDate.toLocalDate(), returnDate.toLocalDate());
+        } else if (returnDate == null && now.isAfter(dueDate)) {
+            return ChronoUnit.DAYS.between(dueDate.toLocalDate(), now.toLocalDate());
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
## 작업 목표
- 장비 대여 생성 요청 및 대여 정보 응답에 사용될 DTO 정의

## 주요 변경 사항
- RentalCreateRequestDto: 장비 대여 신청 시 필요한 equipmentItemIdentifier를 받는 DTO 추가
- RentalResponseDto: 대여 내역 조회 등에서 사용될 응답 DTO를 추가했으며, 중첩된 `EquipmentResponseDto`와 계산된 `overdueDays` 필드 포함

## 참고사항

- 반납 요청 DTO(RentalReturnRequestDto)는 현재 요청 본문에 필요한 데이터가 없어, 나중에 필요 시 추가하도록 하겠습니다.