### PR TITLE
feat(equipment): Implement core Equipment domain (Entity, Repository, Service) and fix

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
@@ -61,4 +61,17 @@ public class Equipment {
             rental.setEquipment(this);
         }
     }
+
+    public void markAsAvailable() {
+    this.status = EquipmentStatus.AVAILABLE;
+    }
+
+    public void markAsRented() {
+    this.status = EquipmentStatus.RENTED;
+    }
+
+    public boolean isAvailable() {
+    return this.status == EquipmentStatus.AVAILABLE;
+    }
+
 }

--- a/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentTypeSummaryDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentTypeSummaryDto.java
@@ -1,0 +1,5 @@
+package com.niceone.sharekit.dto.equipment;
+
+public class EquipmentTypeSummaryDto {
+
+}

--- a/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
@@ -31,6 +31,9 @@ public interface EquipmentRepository extends JpaRepository<Equipment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Equipment e WHERE e.itemIdentifier = :itemIdentifier")
     Optional<Equipment> findByItemIdentifierForUpdate(@Param("itemIdentifier") String itemIdentifier);
+    
+    //itemIdentifier 자동 생성
+    Optional<Equipment> findTopByItemIdentifierStartsWithOrderByItemIdentifierDesc(String prefix);
 
 }
 

--- a/src/main/java/com/niceone/sharekit/service/EquipmentService.java
+++ b/src/main/java/com/niceone/sharekit/service/EquipmentService.java
@@ -1,0 +1,139 @@
+package com.niceone.sharekit.service;
+
+import com.niceone.sharekit.domain.equipment.Equipment;
+import com.niceone.sharekit.domain.equipment.EquipmentStatus;
+import com.niceone.sharekit.dto.equipment.EquipmentCreateRequestDto;
+import com.niceone.sharekit.dto.equipment.EquipmentResponseDto;
+import com.niceone.sharekit.dto.equipment.EquipmentTypeSummaryDto; 
+import com.niceone.sharekit.repository.EquipmentRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator; 
+import java.util.List;
+import java.util.Map; 
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EquipmentService {
+
+    private final EquipmentRepository equipmentRepository;
+
+    @Transactional
+    public EquipmentResponseDto createEquipment(EquipmentCreateRequestDto requestDto) {
+        String typeName = requestDto.getTypeName();
+        String prefix = determinePrefix(typeName);
+        String fullPrefix = prefix + "-";
+
+        int nextSequence = equipmentRepository.findTopByItemIdentifierStartsWithOrderByItemIdentifierDesc(fullPrefix)
+                .map(lastEquipment -> {
+                    String lastIdentifier = lastEquipment.getItemIdentifier();
+                    String numericPart = lastIdentifier.substring(fullPrefix.length());
+                    return Integer.parseInt(numericPart) + 1;
+                })
+                .orElse(1);
+
+        String newItemIdentifier = String.format("%s%03d", fullPrefix, nextSequence);
+        
+        // 장비 이름 자동 넘버링 로직
+        String newName = requestDto.getName() + " " + nextSequence + "번";
+
+        // 동시성 이슈에 대비해 생성된 식별자가 이미 있는지 다시 한 번 확인
+        equipmentRepository.findByItemIdentifier(newItemIdentifier).ifPresent(e -> {
+            throw new IllegalStateException("동일한 장비 식별자가 이미 존재합니다. 다시 시도해주세요.");
+        });
+
+        Equipment equipment = Equipment.builder()
+                .itemIdentifier(newItemIdentifier)
+                .name(newName) // 자동 넘버링된 이름으로 설정
+                .typeName(typeName)
+                .imageUrl(requestDto.getImageUrl())
+                .status(requestDto.getStatus()) 
+                .rentalLocation(requestDto.getRentalLocation())
+                .availableTimeInfo(requestDto.getAvailableTimeInfo())
+                .description(requestDto.getDescription())
+                .additionalInfo(requestDto.getAdditionalInfo())
+                .build();
+        
+        Equipment savedEquipment = equipmentRepository.save(equipment);
+
+        return EquipmentResponseDto.fromEntity(savedEquipment);
+    }
+
+    // RentalService에서 '반납 완료' 처리가 끝났을 때 이 메소드 호출
+    // 장비 상태를 '대여 가능'으로 변경
+    @Transactional
+    public void changeStatusToAvailable(Long equipmentId) {
+        findEquipmentById(equipmentId).markAsAvailable();
+    }
+    // RentalService에서 '대여' 처리가 성공했을 때 이 메소드 호출
+    // 장비 상태를 '대여 중'으로 변경
+    @Transactional
+    public void changeStatusToRented(Long equipmentId) {
+        Equipment equipment = findEquipmentById(equipmentId);
+        if (!equipment.isAvailable()) {
+            throw new IllegalStateException("현재 대여 가능 상태가 아닌 장비입니다.");
+        }
+        equipment.markAsRented();
+    }
+
+    public EquipmentResponseDto getEquipmentById(Long equipmentId) {
+        return equipmentRepository.findById(equipmentId)
+                .map(EquipmentResponseDto::fromEntity)
+                .orElseThrow(() -> new EntityNotFoundException("장비를 찾을 수 없습니다. ID: " + equipmentId));
+    }
+
+    public List<EquipmentResponseDto> findAll() {
+        return equipmentRepository.findAll().stream()
+                .map(EquipmentResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 요약 정보 조회 메소드
+    public List<EquipmentTypeSummaryDto> getEquipmentTypeSummaries() {
+        Map<String, List<Equipment>> groupedByType = equipmentRepository.findAll()
+                .stream()
+                .collect(Collectors.groupingBy(Equipment::getTypeName));
+
+        return groupedByType.entrySet().stream()
+                .map(entry -> {
+                    String typeName = entry.getKey();
+                    List<Equipment> items = entry.getValue();
+
+                    long totalCount = items.size();
+                    long availableCount = items.stream()
+                            .filter(equipment -> equipment.getStatus() == EquipmentStatus.AVAILABLE)
+                            .count();
+                    
+                    String imageUrl = items.stream()
+                            .map(Equipment::getImageUrl)
+                            .filter(url -> url != null && !url.isBlank())
+                            .findFirst()
+                            .orElse(null);
+
+                    return new EquipmentTypeSummaryDto(typeName, imageUrl, totalCount, availableCount);
+                })
+                .sorted(Comparator.comparing(EquipmentTypeSummaryDto::getTypeName))
+                .collect(Collectors.toList());
+    }
+
+    private Equipment findEquipmentById(Long id) {
+        return equipmentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("장비를 찾을 수 없습니다. ID: ".concat(String.valueOf(id))));
+    }
+
+    private String determinePrefix(String typeName) {
+        return switch (typeName) {
+            case "노트북" -> "LAPTOP";
+            case "계산기" -> "CALC";
+            case "충전기" -> "CHARGER";
+            default -> "MISC";
+        };
+    }
+}
+
+


### PR DESCRIPTION
## 작업 목표
- 데이터 모델 정의부터 데이터 접근, 실제 비즈니스 로직 구현

## 주요 변경 사항
- Equipment 엔티티: 상태 관리 메소드(`isAvailable` 등)를 추가하여 기능 확장
- EquipmentRepository: `itemIdentifier` 자동 생성을 위한 조회 메소드 구현 
- EquipmentService: 장비 생성(자동 넘버링 포함), 상태 변경, 요약 정보 조회 등 핵심 비즈니스 로직 구현

## 참고사항

- 엔티티에는 서비스 로직과의 역할 분담을 명확히 하고자 엔티티가 스스로 상태를 변경하고 확인하는 `isAvailable()`, `markAsRented()` 등의 메소드를 포함하도록 수정되었습니다. 이로 인해 데이터베이스 스키마 변경이 필요할 수 있습니다.
- 이 PR이 병합되면 Equipment 도메인에 대한 기본적인 백엔드 기능이 완성되며, 후속 작업으로는 이를 외부에 노출하는 컨트롤러(Controller) 구현이 이어질 예정입니다. 
- 리뷰 시에는 서비스 로직의 흐름, 특히 `itemIdentifier` 생성 로직의 동시성 처리 가능성 및 상태 변경 로직의 명확성을 중점적으로 확인해주시면 감사하겠습니다.
- #[21]에 커밋 명명 규칙을 이탈한 커밋 메시지가 존재하여 수정하였습니다.

Close #[22]