### PR TITLE
feat(user): Add 1:N relationship with Rental to User entity

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/user/User.java
+++ b/src/main/java/com/niceone/sharekit/domain/user/User.java
@@ -4,13 +4,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+// import java.util.ArrayList; > 사용되지 않아 주석 처리 하였음. 확인 요망
 import java.util.HashSet;
 import java.util.Set;
+
+import com.niceone.sharekit.domain.rental.Rental;
+
 import jakarta.persistence.*;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
 
 @Getter
 @Setter
@@ -50,5 +51,17 @@ public class User {
         this.name = name;
         this.studentId = studentId;
         this.password = password;
+    }
+
+    // rental 연관 관계 작성
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Rental> rentals = new HashSet<>();
+
+    public void addRental(Rental rental) {
+        this.rentals.add(rental);
+        if (rental.getUser() != this) {
+            rental.setUser(this);
+        }
     }
 }


### PR DESCRIPTION
## 작업 목표
- User 엔티티에 Rental 엔티티와의 일대다(1:N) 양방향 관계를 설정합니다.

주요 변경 사항
- User.java: set<Rental> rentals 필드를 추가하고 @OneToMany 어노테이션으로 관계 설정
- Arraylist가 사용되지 않아 import java.util.ArrayList; > 주석 처리 

참고사항
- addRental 편의 메소드는 향후 RentalService에서 새로운 대여 기록을 생성할 때 호출되어, User와 Rental 양방향 관계를 안전하게 설정하는 역할을 할 것입니다.