### PR TITLE
feat(security): Configure role-based API access control

### DIFF
--- a/src/main/java/com/niceone/sharekit/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/niceone/sharekit/config/JwtAuthenticationFilter.java
@@ -23,8 +23,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -58,14 +56,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         log.warn("JWT authentication attempt for user UID: {} who has not completed profile setup (studentId or password missing).", uid);
                     }
 
-                    Collection<? extends GrantedAuthority> authorities;
-                    if (user.getRole() != null && !user.getRole().isEmpty()) {
-                        authorities = Arrays.stream(user.getRole().split(","))
-                                .map(SimpleGrantedAuthority::new)
-                                .collect(Collectors.toList());
-                    } else {
-                        authorities = new ArrayList<>();
-                    }
+                    Collection<? extends GrantedAuthority> authorities = user.getRoles().stream()
+                            .map(role -> new SimpleGrantedAuthority(role.getName()))
+                            .collect(Collectors.toList());
 
                     UsernamePasswordAuthenticationToken authentication =
                             new UsernamePasswordAuthenticationToken(user, null, authorities);
@@ -106,11 +99,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * HttpServletRequest 에서 Authorization 헤더를 가로채서 Bearer 토큰을 추출
-     * @param request HttpServletRequest 객체
-     * @return 추출된 JWT 문자열 또는 null
-     */
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {

--- a/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
+++ b/src/main/java/com/niceone/sharekit/config/SecurityConfig.java
@@ -35,28 +35,23 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .addFilterBefore(firebaseTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                // SecurityConfig.java (authorizeHttpRequests 부분)
+                .addFilterBefore(firebaseTokenFilter, JwtAuthenticationFilter.class)
+
                 .authorizeHttpRequests(authz -> authz
                         // 1. 인증 없이 접근 허용
                         .requestMatchers(
                                 PathRequest.toStaticResources().atCommonLocations(),
-
-                                // 정적 리소스 (css, js, images)
                                 AntPathRequestMatcher.antMatcher("/js/**"),
                                 AntPathRequestMatcher.antMatcher("/css/**"),
                                 AntPathRequestMatcher.antMatcher("/images/**"),
-                                // HTML 페이지 경로 (GET 요청)
                                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/"),
                                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/login"),
                                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/signup"),
                                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/profile"),
                                 AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/equipment-list"),
-                                // API 인증/인가 관련 경로
                                 AntPathRequestMatcher.antMatcher("/api/auth/signup"),
                                 AntPathRequestMatcher.antMatcher("/api/auth/login"),
-                                // 기타 공개 경로
                                 AntPathRequestMatcher.antMatcher("/public/**"),
                                 AntPathRequestMatcher.antMatcher("/error"),
                                 AntPathRequestMatcher.antMatcher("/favicon.ico"),
@@ -65,18 +60,21 @@ public class SecurityConfig {
                                 AntPathRequestMatcher.antMatcher("/swagger-resources/**")
                         ).permitAll()
 
-                        // 2. Firebase 토큰 인증 필요한 경로
-                        .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.PUT, "/api/users/me/profile"))
-                        .hasAnyAuthority("ROLE_PRE_AUTH_USER", "ROLE_USER", "ROLE_ADMIN")
+                        // 2. 프로필 업데이트: PRE_AUTH_USER 또는 USER 역할이 필요
+                        // PRE_AUTH_USER는 최초 등록을 위해, USER는 정보 수정을 위해 접근
+                        .requestMatchers(HttpMethod.PUT, "/api/users/me/profile")
+                        .hasAnyRole("PRE_AUTH_USER", "USER")
 
-                        // 3. JWT 인증 필요한 API 경로들
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/api/**"))
-                        .hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
+                        // 3. 관리자 전용 API (향후 확장 예정)
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                        // 4. 지정되지 않은 나머지 요청은 인증 요구
+                        // 4. 나머지 모든 /api/** 경로는 USER 또는 ADMIN 역할 필요
+                        // 물품 대여/반납, 내역 조회 등 대부분의 기능
+                        .requestMatchers("/api/**").hasAnyRole("USER", "ADMIN")
+
+                        // 5. 그 외 모든 요청은 일단 인증만 되면 허용
                         .anyRequest().authenticated()
                 );
-
         return http.build();
     }
 }


### PR DESCRIPTION
## 작업 목표

Spring Security 설정을 업데이트하여, 사용자 역할(`ROLE_PRE_AUTH_USER`, `ROLE_USER`, `ROLE_ADMIN`)에 따라 API 엔드포인트 접근을 제어

## 주요 변경 사항

- **인증 필터 수정 (`FirebaseTokenFilter`, `JwtAuthenticationFilter`)**
    - 사용자의 `Set<Role>` 정보를 올바르게 읽어 Security Context에 다중 권한을 부여하도록 로직을 개선

- **SecurityConfig 접근 권한 규칙 수정**
    - `hasRole()`을 사용하여 역할 기반으로 인가 규칙을 재정의
    - `/api/users/me/profile` 경로는 `PRE_AUTH_USER`와 `USER` 역할 모두 접근 가능하도록 설정
    - 나머지 `/api/**` 경로는 `USER` 또는 `ADMIN` 역할이 필요하도록 설정