### PR TITLE
feat(service): equipment service update

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/Equipment.java
@@ -1,6 +1,8 @@
 package com.niceone.sharekit.domain.equipment;
 
 import com.niceone.sharekit.domain.rental.Rental;
+import com.niceone.sharekit.dto.equipment.EquipmentUpdateRequestDto;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Builder;
@@ -62,16 +64,51 @@ public class Equipment {
         }
     }
 
-    public void markAsAvailable() {
-    this.status = EquipmentStatus.AVAILABLE;
+    public boolean isAvailable() {
+        return this.status == EquipmentStatus.AVAILABLE;
     }
 
     public void markAsRented() {
-    this.status = EquipmentStatus.RENTED;
+        this.status = EquipmentStatus.RENTED;
     }
 
-    public boolean isAvailable() {
-    return this.status == EquipmentStatus.AVAILABLE;
+    public void markAsAvailable() {
+        this.status = EquipmentStatus.AVAILABLE;
     }
 
+    public void markAsInRepair() {
+        if (this.status == EquipmentStatus.RENTED) {
+            throw new IllegalStateException("대여 중인 장비는 수리 상태로 변경할 수 없습니다.");
+        }
+        this.status = EquipmentStatus.IN_REPAIR;
+    }
+
+    //DTO로부터 받은 정보로 장비의 상세 내용 업데이트 
+    public void update(EquipmentUpdateRequestDto requestDto) {
+        if (requestDto.getName() != null) {
+            this.name = requestDto.getName();
+        }
+        if (requestDto.getTypeName() != null) {
+            this.typeName = requestDto.getTypeName();
+        }
+        if (requestDto.getImageUrl() != null) {
+            this.imageUrl = requestDto.getImageUrl();
+        }
+        if (requestDto.getStatus() != null) {
+            this.status = requestDto.getStatus();
+        }
+        if (requestDto.getRentalLocation() != null) {
+            this.rentalLocation = requestDto.getRentalLocation();
+        }
+        if (requestDto.getAvailableTimeInfo() != null) {
+            this.availableTimeInfo = requestDto.getAvailableTimeInfo();
+        }
+        if (requestDto.getDescription() != null) {
+            this.description = requestDto.getDescription();
+        }
+        if (requestDto.getAdditionalInfo() != null) {
+            this.additionalInfo = requestDto.getAdditionalInfo();
+        }
+
+    }
 }

--- a/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatusHistory.java
+++ b/src/main/java/com/niceone/sharekit/domain/equipment/EquipmentStatusHistory.java
@@ -1,0 +1,43 @@
+package com.niceone.sharekit.domain.equipment;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class) // 생성일 자동 기록
+public class EquipmentStatusHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "equipment_id", nullable = false)
+    private Equipment equipment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EquipmentStatus status; 
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime changeDate; // 상태 변경일
+
+    private String note; // 비고 (ex: "사용자 A가 대여", "수리 완료")
+
+    @Builder
+    public EquipmentStatusHistory(Equipment equipment, EquipmentStatus status, String note) {
+        this.equipment = equipment;
+        this.status = status;
+        this.note = note;
+    }
+}

--- a/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentBriefDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentBriefDto.java
@@ -1,0 +1,18 @@
+package com.niceone.sharekit.dto.equipment;
+
+import lombok.Getter;
+
+@Getter
+public class EquipmentBriefDto {
+    private final Long id;
+    private final String name;
+    private final String itemIdentifier;
+    private final String displayStatus; // "대여 가능", "대여 중", "연체 중", "수리 중"
+
+    public EquipmentBriefDto(Long id, String name, String itemIdentifier, String displayStatus) {
+        this.id = id;
+        this.name = name;
+        this.itemIdentifier = itemIdentifier;
+        this.displayStatus = displayStatus;
+    }
+}

--- a/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentDetailDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentDetailDto.java
@@ -1,0 +1,42 @@
+package com.niceone.sharekit.dto.equipment;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EquipmentDetailDto {
+    private final Long id;
+    private final String name;
+    private final String rentalLocation;
+    private final String displayStatus;
+    private final LocalDate dueDate; // 반납일 (조건부 표시)
+    private final List<StatusHistoryDto> statusHistories; // 상태 내역
+
+    public EquipmentDetailDto(Long id, String name, String rentalLocation, String displayStatus, LocalDate dueDate, List<StatusHistoryDto> statusHistories) {
+        this.id = id;
+        this.name = name;
+        this.rentalLocation = rentalLocation;
+        this.displayStatus = displayStatus;
+        this.dueDate = dueDate;
+        this.statusHistories = statusHistories;
+    }
+
+    // 상태 내역을 위한 내부 DTO
+    @Getter
+    public static class StatusHistoryDto {
+        private final String status;
+        private final LocalDateTime changeDate;
+        private final String note;
+
+        public StatusHistoryDto(String status, LocalDateTime changeDate, String note) {
+            this.status = status;
+            this.changeDate = changeDate;
+            this.note = note;
+        }
+    }
+}

--- a/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentTypeSummaryDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/equipment/EquipmentTypeSummaryDto.java
@@ -7,7 +7,7 @@ public class EquipmentTypeSummaryDto {
     private String typeName; 
     private String imageUrl; 
     private long totalCount; 
-    private long availableCount; // 현재 대여 가능한 장비 개수수
+    private long availableCount; // 현재 대여 가능한 장비 개수
 
     public EquipmentTypeSummaryDto(String typeName, String imageUrl, long totalCount, long availableCount) {
         this.typeName = typeName;

--- a/src/main/java/com/niceone/sharekit/repository/EquipmentStatusHistoryRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/EquipmentStatusHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.niceone.sharekit.repository;
+
+import com.niceone.sharekit.domain.equipment.EquipmentStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EquipmentStatusHistoryRepository extends JpaRepository<EquipmentStatusHistory, Long> {
+    
+    List<EquipmentStatusHistory> findByEquipmentIdOrderByChangeDateDesc(Long equipmentId);
+}

--- a/src/main/java/com/niceone/sharekit/repository/RentalRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/RentalRepository.java
@@ -21,4 +21,11 @@ public interface RentalRepository extends JpaRepository<Rental, Long> {
 
     // Rental 상태 관련 조회
     List<Rental> findByStatus(RentalStatus status);
+
+     
+     //현재 '대여 중(RENTED)' 상태인 대여 기록을 찾음
+    Optional<Rental> findByEquipmentIdAndStatus(Long equipmentId, RentalStatus status);
+
+    // 여러 장비에 대해 현재 '대여 중(RENTED)' 상태인 대여 기록들을 한 번의 쿼리로 조회
+    List<Rental> findByEquipmentIdInAndStatus(List<Long> equipmentIds, RentalStatus status);
 }


### PR DESCRIPTION
## 작업 목표

- 사용자 페이지 요구 사항에 맞춰 장비 관련 로직을 전면적으로 개편 

## 주요 변경 사항

- UI 페이지별 요구사항에 맞춰 EquipmentTypeSummaryDto, EquipmentBriefDto, EquipmentDetailDto 추가
- 장비의 모든 상태 변화를 기록하기 위해 EquipmentStatusHistory 엔티티와 Repository 추가
- 장비 생성, 대여, 반납, 수리 등 모든 상태 변경 로직에 이력 기록 기능 통합, 
- 관리자가 장비 상태를 '수리 중' 또는 '수리 완료'로 변경할 수 있는 신규 메서드 추가
- 컴파일 오류 수정: RentalRepository에 findByEquipmentIdAndStatus, findByEquipmentIdInAndStatus 메서드를 추가하여 EquipmentService의 컴파일 오류 해결

## 참고 사항

- DB 데이터를 조합하여 UI에 필요한 displayStatus를 동적으로 생성하는 로직을 중점적으로 검토 부탁드립니다.
- 새롭게 추가된 EquipmentStatusHistory가 장비의 라이프사이클을 잘 추적할 수 있을지 확인 부탁드립니다.
- RentalRepository에 메서드를 추가하는 부분이 선행되어야 EquipmentService가 정상적으로 동작하므로, 해당 부분부터 확인하시면 전체적인 흐름을 이해하기 수월합니다.
