### PR TITLE
feat(service): Implement RentalService business logic

### DIFF
--- a/src/main/java/com/niceone/sharekit/domain/rental/Rental.java
+++ b/src/main/java/com/niceone/sharekit/domain/rental/Rental.java
@@ -43,4 +43,34 @@ public class Rental {
     @Column(nullable = false, length = 30)
     private RentalStatus status; // 대여 상태 (Enum: RENTED, RETURNED, OVERDUE 등)
 
+    private String note;
+
+    @Builder
+    public Rental(User user, Equipment equipment, RentalStatus status, LocalDateTime rentalDate, LocalDateTime dueDate) {
+        this.user = user;
+        this.equipment = equipment;
+        this.status = status;
+        this.rentalDate = rentalDate;
+        this.dueDate = dueDate;
+    }
+
+    /**
+     * 대여 기록을 '반납 완료' 상태로 변경
+     * 관리자에 의한 일반 반납 및 예외적 상태 변경 시 호출
+     */
+    public void complete() {
+        if (this.status == RentalStatus.RENTED) {
+            this.status = RentalStatus.RETURNED;
+            this.returnDate = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * '수리 보내기' 등 특정 사유와 함께 반납 처리할 때 사용되는 메서드 오버로딩
+     * @param reason 사유 (note 필드에 저장됩니다)
+     */
+    public void complete(String reason) {
+        this.complete(); // 기본 반납 처리 로직 호출
+        this.note = reason;
+    }
 }

--- a/src/main/java/com/niceone/sharekit/dto/rental/AdminRentalUpdateRequestDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/rental/AdminRentalUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.niceone.sharekit.dto.rental;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminRentalUpdateRequestDto {
+    private String newStatus;
+}
+

--- a/src/main/java/com/niceone/sharekit/dto/rental/RentalRequestDto.java
+++ b/src/main/java/com/niceone/sharekit/dto/rental/RentalRequestDto.java
@@ -1,0 +1,10 @@
+package com.niceone.sharekit.dto.rental;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RentalRequestDto {
+    private Long equipmentId;
+}

--- a/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
+++ b/src/main/java/com/niceone/sharekit/repository/EquipmentRepository.java
@@ -35,5 +35,10 @@ public interface EquipmentRepository extends JpaRepository<Equipment, Long> {
     //itemIdentifier 자동 생성
     Optional<Equipment> findTopByItemIdentifierStartsWithOrderByItemIdentifierDesc(String prefix);
 
+    //동시성 제어를 위한 비관적 쓰기 잠금(대여 시)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Equipment e WHERE e.id = :id")
+    Optional<Equipment> findByIdWithPessimisticLock(@Param("id") Long id);
+
 }
 

--- a/src/main/java/com/niceone/sharekit/service/RentalService.java
+++ b/src/main/java/com/niceone/sharekit/service/RentalService.java
@@ -1,0 +1,109 @@
+package com.niceone.sharekit.service;
+
+import com.niceone.sharekit.domain.equipment.Equipment;
+import com.niceone.sharekit.domain.rental.Rental;
+import com.niceone.sharekit.domain.rental.RentalStatus;
+import com.niceone.sharekit.domain.user.User;
+import com.niceone.sharekit.dto.rental.AdminRentalUpdateRequestDto;
+import com.niceone.sharekit.dto.rental.RentalRequestDto;
+import com.niceone.sharekit.dto.rental.RentalResponseDto;
+import com.niceone.sharekit.repository.EquipmentRepository;
+import com.niceone.sharekit.repository.RentalRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RentalService {
+
+    private final RentalRepository rentalRepository;
+    private final EquipmentRepository equipmentRepository;
+    private final EquipmentService equipmentService;
+
+    private static final int RENTAL_PERIOD_DAYS = 7;
+
+    /**
+     * 사용자: 장비 대여
+     */
+    public RentalResponseDto createRental(RentalRequestDto requestDto, User user) {
+        Long equipmentId = requestDto.getEquipmentId();
+
+        // 1. 비관적 잠금을 사용하여 동시 대여 방지
+        Equipment equipment = equipmentRepository.findByIdWithPessimisticLock(equipmentId)
+                .orElseThrow(() -> new EntityNotFoundException("장비를 찾을 수 없습니다. ID: " + equipmentId));
+
+        if (!equipment.isAvailable()) {
+            throw new IllegalStateException("현재 대여 가능한 상태가 아닌 장비입니다.");
+        }
+
+        // 2. 장비 상태 변경 및 이력 기록
+        equipmentService.handleRental(equipment.getId(), user.getName());
+
+        // 3. 대여 엔티티 생성 및 저장
+        Rental rental = Rental.builder()
+                .user(user)
+                .equipment(equipment)
+                .rentalDate(LocalDateTime.now())
+                .dueDate(LocalDateTime.now().plusDays(RENTAL_PERIOD_DAYS))
+                .status(RentalStatus.RENTED)
+                .build();
+        
+        user.addRental(rental);
+
+        Rental savedRental = rentalRepository.save(rental);
+        return new RentalResponseDto(savedRental);
+    }
+
+    /**
+     * 관리자: 장비 반납 처리
+     * @param rentalId 반납 처리할 대여 기록의 ID
+     */
+    public RentalResponseDto returnRentalByAdmin(Long rentalId) {
+        Rental rental = rentalRepository.findById(rentalId)
+                .orElseThrow(() -> new EntityNotFoundException("대여 기록을 찾을 수 없습니다. ID: " + rentalId));
+        
+        if (rental.getStatus() != RentalStatus.RENTED) {
+            throw new IllegalStateException("현재 '대여 중' 상태인 기록만 반납 처리할 수 있습니다.");
+        }
+
+        // 1. 장비 상태를 'AVAILABLE'로 변경하고 이력 기록
+        equipmentService.handleReturn(rental.getEquipment().getId());
+
+        // 2. 대여 기록의 상태를 'RETURNED'로 변경
+        rental.complete();
+
+        return new RentalResponseDto(rental);
+    }
+    
+    /**
+     * 관리자: '수리 보내기' 등 예외적인 상태 변경 처리
+     * @param rentalId 변경할 대여 기록의 ID
+     * @param updateDto 변경할 상태 정보를 담은 DTO
+     */
+    public RentalResponseDto updateRentalStatusByAdmin(Long rentalId, AdminRentalUpdateRequestDto updateDto) {
+        Rental rental = rentalRepository.findById(rentalId)
+                .orElseThrow(() -> new EntityNotFoundException("대여 기록을 찾을 수 없습니다. ID: " + rentalId));
+        
+        if (rental.getStatus() != RentalStatus.RENTED) {
+            throw new IllegalStateException("현재 '대여 중' 상태인 기록만 상태를 변경할 수 있습니다.");
+        }
+
+        Long equipmentId = rental.getEquipment().getId();
+
+        if ("IN_REPAIR".equals(updateDto.getNewStatus())) {
+            // 1. 장비를 '수리 중' 상태로 변경하고 이력 기록
+            equipmentService.markEquipmentAsInRepair(equipmentId);
+            // 2. 대여 기록은 '반납' 처리하되, 사유를 남김
+            rental.complete("관리자에 의해 수리 상태로 변경됨");
+        } else {
+            throw new IllegalArgumentException("유효하지 않은 상태 값입니다: " + updateDto.getNewStatus());
+        }
+
+        return new RentalResponseDto(rental);
+    }
+}


### PR DESCRIPTION
## 작업 목표

- 사용자가 장비를 대여하고, 관리자가 반납 및 대여 상태를 관리할 수 있는 RentalService의 핵심 기능 구현

## 주요 변경 사항
- 사용자 대여 기능: 사용자가 장비를 대여할 수 있는 createRental 로직 구현
- 관리자 반납 기능: 관리자만 장비를 반납 처리할 수 있는 returnRentalByAdmin 로직 구현
- 관리자 상태 변경 기능: 관리자가 대여 중인 장비를 '수리 중' 상태로 변경하는 등 예외적인 상황을 처리할 수 있는 updateRentalStatusByAdmin 로직 추가

## 참고사항
- 기획에 따라, 모든 '반납' 처리는 이제 관리자만 수행할 수 있도록 로직이 구현되었습니다.
- DB 주의사항: EquipmentRepository에 추가된 findByIdWithPessimisticLock 메서드는 동시성 제어의 핵심이므로, 관련 로직 수정 시 주의가 필요합니다.