### PR TITLE
fix(security): Modify JwtTokenProvider to use getRoles

### DIFF
--- a/src/main/java/com/niceone/sharekit/service/JwtTokenProvider.java
+++ b/src/main/java/com/niceone/sharekit/service/JwtTokenProvider.java
@@ -70,10 +70,11 @@ public class JwtTokenProvider {
      * @return 생성된 JWT 문자열
      */
     public String generateToken(User user) {
-        String authorities = "";
-        if (user.getRole() != null && !user.getRole().isEmpty()) {
-            authorities = user.getRole();
-        }
+        // *** 여기가 핵심 변경 부분입니다 ***
+        // 사용자의 Set<Role>을 쉼표로 구분된 문자열로 변환합니다.
+        String authorities = user.getRoles().stream()
+                .map(role -> role.getName())
+                .collect(Collectors.joining(","));
 
         Date now = new Date();
         Date validity = new Date(now.getTime() + this.tokenValidityInMilliseconds);
@@ -87,7 +88,6 @@ public class JwtTokenProvider {
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
-
 
     /**
      * JWT 토큰에서 사용자 UID (Subject)를 추출합니다.


### PR DESCRIPTION
## 작업 목표

`User` 엔티티의 역할 관리 체계가 `Set<Role>`으로 변경되었음에도 불구하고, `JwtTokenProvider`의 특정 메소드에서 이전 방식인 `getRole()`을 계속 사용하고 있던 버그를 수정

## 주요 변경 사항

- **`JwtTokenProvider.java`의 `generateToken(User user)` 메소드 수정**
    - `user.getRole()`을 호출하던 기존 로직을 제거
    - `user.getRoles()`를 사용하여 `Set<Role>`에서 역할 정보를 가져온 뒤, 이를 쉼표로 구분된 문자열로 변환하여 토큰의 권한(authorities) 클레임에 저장하도록 수정

## 기타 사항

- 이 수정을 통해 모든 JWT 생성 로직이 현재의 다중 역할 시스템과 일치하게 됩니다.