### PR TITLE
chore: Separate configuration for local and shared profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### firebase initialize key ###
 serviceAccountPath.json
+
+### Local Environment Configurations
+src/main/resources/application-local.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,25 @@
+# ??? ??? ??
+spring.profiles.active=local
+
+# ?????? ??
 spring.application.name=sharekit
 
-spring.datasource.url=jdbc:mysql://localhost:3306/sharekit
-spring.datasource.username=root
-spring.datasource.password=root
+# DB ????
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA ??
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Spring Security
+spring.security.user.name=admin
+
+# JWT ?? ????
+jwt.token-validity-in-seconds=86400
+
+# Log ?? ??
+logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=DEBUG
+logging.level.com.sharekit=DEBUG


### PR DESCRIPTION
## 작업 목표
- 로컬 개발 환경에서 개인마다 다른 DB 비밀번호, JWT 시크릿 키 등의 민감 정보를 Git에 커밋하지 않도록 설정 파일을 분리

## 주요 변경 사항
- `application.properties`: 공통 설정을 남기고, `local` 프로필을 활성화하도록 수정
- `application-local.properties`: DB 접속 정보, JWT 시크릿 등 민감 정보를 포함하는 개인 설정 파일
- `.gitignore`: `application-local.properties` 파일이 Git 추적에서 제외되도록 추가

## 참고사항
- 이 PR이 병합된 후, 모든 팀원은 각자의 로컬 환경에 맞는 `application-local.properties` 파일을 생성해야 합니다.