### PR TITLE
Fix: Add missing authorization to EquipmentController

### DIFF
--- a/src/main/java/com/niceone/sharekit/controller/EquipmentController.java
+++ b/src/main/java/com/niceone/sharekit/controller/EquipmentController.java
@@ -21,6 +21,8 @@ public class EquipmentController {
      * 메인 페이지: 장비 종류별 요약 정보 조회
      */
     @GetMapping("/equipments/summary")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')") 
+
     public ResponseEntity<List<EquipmentTypeSummaryDto>> getEquipmentSummaries() {
         return ResponseEntity.ok(equipmentService.getEquipmentTypeSummaries());
     }
@@ -30,6 +32,7 @@ public class EquipmentController {
      * @param typeName 조회할 장비의 종류
      */
     @GetMapping("/equipments/type/{typeName}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')") 
     public ResponseEntity<List<EquipmentBriefDto>> getEquipmentsByType(@PathVariable String typeName) {
         return ResponseEntity.ok(equipmentService.getEquipmentListByType(typeName));
     }
@@ -39,6 +42,7 @@ public class EquipmentController {
      * @param equipmentId 조회할 장비의 ID
      */
     @GetMapping("/equipments/{equipmentId}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ResponseEntity<EquipmentDetailDto> getEquipmentDetail(@PathVariable Long equipmentId) {
         return ResponseEntity.ok(equipmentService.getEquipmentDetail(equipmentId));
     }


### PR DESCRIPTION
## 작업 목표
- SecurityConfig.java에 정의된 중앙 보안 정책과 EquipmentController.java의 실제 동작을 일치시키고자 함.

## 주요 변경 사항
- 아래 메서드들에 @PreAuthorize("hasAnyRole('USER', 'ADMIN')") 어노테이션 추가
- getEquipmentSummaries(), getEquipmentsByType(), getEquipmentDetail() 해당 API들은 SecurityConfig의 .requestMatchers("/api/**").hasAnyRole("USER", "ADMIN") 규칙에 따라 USER 또는 ADMIN 역할을 가진 인증된 사용자만 접근 가능
## 참고사항
- RentalController.java의 경우, 검토 결과 기존 어노테이션이 SecurityConfig 정책과 이미 일치하여 별도 수정 작업을 진행하지 않았습니다.