### PR TITLE
feat: Add equipment-list html, css

### DIFF
--- a/src/main/resources/static/css/equipment-globals.css
+++ b/src/main/resources/static/css/equipment-globals.css
@@ -1,0 +1,18 @@
+@import url("https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css");
+* {
+    -webkit-font-smoothing: antialiased;
+    box-sizing: border-box;
+}
+html,
+body {
+    margin: 0px;
+    height: 100%;
+}
+/* a blue color as a generic focus style */
+button:focus-visible {
+    outline: 2px solid #4a90e2 !important;
+    outline: -webkit-focus-ring-color auto 5px !important;
+}
+a {
+    text-decoration: none;
+}

--- a/src/main/resources/static/css/equipment.css
+++ b/src/main/resources/static/css/equipment.css
@@ -1,0 +1,451 @@
+@font-face {
+    font-family: 'HUFS_B';
+    src: url('/fonts/HUFS_B.ttf') format('truetype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'HUFS_L';
+    src: url('/fonts/HUFS_L.ttf') format('truetype');
+    font-weight: 300;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'gamtan_B';
+    src: url('/fonts/gamtan_B.otf') format('opentype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'gamtan_R';
+    src: url('/fonts/gamtan_R.otf') format('opentype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+
+.screen {
+    background-color: #ffffff;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+  }
+  
+  .screen .div {
+    background-color: #ffffff;
+    width: 1440px;
+    height: 1024px;
+    position: relative;
+  }
+  
+  .screen .overlap {
+    height: 733px;
+    top: 291px;
+    position: absolute;
+    width: 1440px;
+    left: 0;
+  }
+  
+  .screen .span {
+    font-size: 55px;
+  }
+  
+  .screen .text-wrapper-2 {
+    font-size: 50px;
+    color: #8d7150;
+    
+  }
+
+  .screen .text-wrapper-5 {
+    color: #002d56;
+    font-size: 11.2px;
+    line-height: 15.7px;
+  }
+  
+  .screen .overlap-group {
+    height: 111px;
+    top: -1px;
+    position: absolute;
+    width: 1440px;
+    left: 0;
+  }
+  
+  .screen .navigation-header {
+    position: absolute;
+    width: 1440px;
+    height: 84px;
+    top: 27px;
+    left: 0;
+  }
+  
+  .screen .BG {
+    height: 52px;
+    background-color: #ffffff;
+    box-shadow: inset 0px -1px 0px #eaeaea;
+  }
+  
+  .screen .p {
+    position: absolute;
+    width: 242px;
+    height: 74px;
+    top: 0;
+    left: 50px;
+    font-family: "HUFS_B", Helvetica;
+    font-weight: 400;
+    color: transparent;
+    font-size: 32px;
+    letter-spacing: 0;
+    line-height: 44.8px;
+  }
+  
+  .screen .text-wrapper-3 {
+    color: #8d7150;
+  }
+  
+  .screen .text-wrapper-4 {
+    color: #000000;
+    font-size: 15px;
+    line-height: 15.0px;
+  }
+  
+  .screen .logo-subtitle {
+    color: #002d56;
+    font-size: 11.2px;
+    line-height: 15.7px;
+  }
+  
+  
+  .screen .div-wrapper {
+    position: absolute;
+    width: 86px;
+    height: 36px;
+    top: 19px;
+    left: 1176px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 56px;
+    justify-content: center;
+    background-color: var(--ui-elementprimary);
+    border-radius: 24px;
+    box-shadow: 0px 1px 5px #00000040;
+  }
+  
+  
+  
+  .screen .div-2 {
+    position: absolute;
+    width: 785px;
+    top: 224px;
+    left: 327px;
+    font-family: "gamtan_B", Helvetica;
+    font-weight: 700;
+    color: transparent;
+    font-size: 65px;
+    text-align: center;
+    letter-spacing: 0;
+    line-height: 50px;
+  }
+  
+  .screen .text-wrapper-6 {
+    color: #000000;
+    font-size: 50px;
+  }
+  /* Inject original CSS here */
+  
+  /* New and modified styles */
+  .screen {
+    min-height: 100vh;
+  }
+  
+  .main-content {
+    position: relative;
+    width: 100%;
+    max-width: 1440px;
+    margin: 0 auto;
+  }
+  
+  .header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+  }
+  
+  .navigation-header {
+    position: relative;
+    width: 100%;
+    height: 84px;
+    padding: 0 50px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  
+  .logo {
+    font-family: "HUFS_B", Helvetica;
+    font-weight: 400;
+    font-size: 32px;
+    line-height: 0.5;
+  }
+  
+  .nav-links {
+    display: flex;
+    gap: 27px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  
+  .nav-button {
+    display: inline-block;
+    padding: 7px 15px;
+    font-family: "HUFS_B", Helvetica;
+    font-weight: 400;
+    color: #002d56;
+    font-size: 14px;
+    text-align: center;
+    line-height: 1.4;
+    white-space: nowrap;
+    background-color: var(--ui-elementprimary);
+    border-radius: 24px;
+    box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.25);
+    transition: background-color 0.3s, color 0.3s;
+  }
+  
+  .nav-button:hover,
+  .nav-button:focus {
+    background-color: #002d56;
+    color: var(--ui-elementprimary);
+  }
+  
+  .nav-button.login {
+    background-color: rgba(160, 160, 160, 0.3);
+  }
+  
+ 
+  
+  @media (max-width: 768px) {
+    .navigation-header {
+      flex-direction: column;
+      height: auto;
+      padding: 20px;
+    }
+  
+    .nav-links {
+      flex-wrap: wrap;
+      justify-content: center;
+      margin-top: 20px;
+    }
+  
+    
+  }
+  
+.div-wrapper {
+    background-color: #ffffff;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    width: 100%;
+}
+
+.div-wrapper .div {
+    background-color: #ffffff;
+    width: 1440px;
+    height: 1024px;
+    position: relative;
+}
+
+.div-wrapper .overlap {
+    top: 115px;
+    left: 515px;
+    position: absolute;
+    width: 410px;
+    height: 409px;
+}
+
+.div-wrapper .rectangle {
+    position: absolute;
+    width: 390px;
+    height: 389px;
+    top: 0;
+    left: 0;
+    border: rgba(0, 0, 0, 1);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.3);
+}
+
+.div-wrapper .text-wrapper {
+    top: 307px;
+    left: 118px;
+    color: #767676;
+    font-size: 20px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .text-wrapper-2 {
+    top: 276px;
+    left: 143px;
+    color: #000000;
+    font-size: 25px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .image {
+    position: absolute;
+    width: 169px;
+    height: 218px;
+    top: 50px;
+    left: 120px;
+}
+
+.div-wrapper .overlap-group {
+    top: 115px;
+    left: 69px;
+    position: absolute;
+    width: 410px;
+    height: 409px;
+}
+
+.div-wrapper .text-wrapper-3 {
+    top: 276px;
+    left: 169px;
+    color: #000000;
+    font-size: 25px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .img {
+    position: absolute;
+    width: 287px;
+    height: 194px;
+    top: 62px;
+    left: 61px;
+}
+
+.div-wrapper .overlap-group-2 {
+    top: 556px;
+    left: 515px;
+    position: absolute;
+    width: 410px;
+    height: 409px;
+}
+
+.div-wrapper .p {
+    top: 314px;
+    left: 118px;
+    color: #767676;
+    font-size: 20px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .text-wrapper-4 {
+    top: 283px;
+    left: 169px;
+    color: #000000;
+    font-size: 25px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .image-2 {
+    position: absolute;
+    width: 228px;
+    height: 228px;
+    top: 45px;
+    left: 85px;
+    object-fit: cover;
+}
+
+.div-wrapper .overlap-2 {
+    top: 556px;
+    left: 69px;
+    position: absolute;
+    width: 410px;
+    height: 409px;
+}
+
+.div-wrapper .text-wrapper-5 {
+    top: 283px;
+    left: 181px;
+    color: #000000;
+    font-size: 25px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .image-3 {
+    position: absolute;
+    width: 187px;
+    height: 187px;
+    top: 62px;
+    left: 110px;
+    object-fit: cover;
+}
+
+.div-wrapper .overlap-3 {
+    top: 115px;
+    left: 961px;
+    position: absolute;
+    width: 410px;
+    height: 409px;
+}
+
+.div-wrapper .text-wrapper-6 {
+    top: 307px;
+    left: 130px;
+    color: #767676;
+    font-size: 20px;
+    position: absolute;
+    font-family: "GamtanRoad Dotum-Bold", Helvetica;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 1.00px;
+    line-height: 44px;
+    white-space: nowrap;
+}
+
+.div-wrapper .image-4 {
+    position: absolute;
+    width: 148px;
+    height: 194px;
+    top: 62px;
+    left: 143px;
+}

--- a/src/main/resources/templates/equipment-list.html
+++ b/src/main/resources/templates/equipment-list.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/equipment-globals.css" />
+    
+    <link rel="stylesheet" href="/css/equipment.css" />
+    <title>SHARE - KIT: 한국외국어대학교 공과대학 물품대여 서비스</title>
+
+    <style>
+        @font-face {
+            font-family: 'HUFS_B';
+            src: url('/fonts/HUFS_B.ttf') format('truetype');
+            font-weight: bold;
+            font-style: normal;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'HUFS_B', sans-serif;
+            background-color: #fff;
+        }
+
+        .logo h1.text-wrapper-2 {
+            font-size: 32px;
+            font-family: 'HUFS_B';
+            margin: 0;
+        }
+
+        .logo span.text-wrapper-5 {
+            font-size: 11.2px;
+            font-family: 'HUFS_B';
+        }
+
+        #equipment-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(390px, 1fr));
+            gap: 20px;
+            padding: 40px;
+            justify-content: center;
+        }
+
+        .overlap-group {
+            width: 390px;
+            height: 389px;
+            background-color: #ffffff;
+            border-radius: 16px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            padding: 20px;
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .overlap-group img.image {
+            max-width: 100%;
+            max-height: 200px;
+            object-fit: contain;
+            margin-bottom: 15px;
+        }
+
+        .equipment-name {
+            font-size: 18px;
+            font-weight: bold;
+            margin: 6px 0 4px;
+        }
+
+        .available-count {
+            font-size: 14px;
+            color: #666;
+            font-weight: normal;
+        }
+    </style>
+</head>
+<body>
+    <div class="screen">
+        <main class="main-content">
+            <header class="header">
+                <nav class="navigation-header">
+                    <div class="BG"></div>
+                    <div class="logo">
+                        <h1 class="text-wrapper-2">SHARE - KIT</h1>
+                        <span class="text-wrapper-5">한국외국어대학교 공과대학 물품대여 서비스</span>
+                    </div>
+                    <ul class="nav-links">
+                        <li><a href="/equipment-list" class="nav-button">물품 목록</a></li>
+                        <li><a href="/addEquipment" class="nav-button">물품 등록</a></li>
+                        <li><a href="/changeStatus" class="nav-button">반납 승인</a></li>
+                        <li><a href="/login" class="nav-button login">Log Out</a></li>
+                    </ul>
+                </nav>
+            </header>
+
+            <div class="div-wrapper">
+                <div class="div" id="equipment-container">
+                    <!-- 장비 카드가 JS로 삽입됨 -->
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            const BASE_URL = '/api';
+
+            const renderEquipments = (summaries) => {
+                const container = document.getElementById('equipment-container');
+                container.innerHTML = '';
+
+                summaries.forEach(summary => {
+                    const { typeName, availableCount, imageUrl } = summary;
+
+                    const card = document.createElement('div');
+                    card.className = 'overlap-group';
+                    card.setAttribute('data-type', typeName);
+
+                    card.innerHTML = `
+                        <img class="image" src="${imageUrl}" alt="${typeName}" />
+                        <div class="equipment-name">${typeName}</div>
+                        <p class="available-count">대여 가능 개수 : ${availableCount}</p>
+                    `;
+
+                    container.appendChild(card);
+                });
+            };
+
+            fetch(`${BASE_URL}/equipments/summary`)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(renderEquipments)
+                .catch(error => {
+                    console.error("장비 요약 정보 불러오기 실패:", error);
+                    alert("장비 대여 가능 개수를 불러오는 데 실패했습니다. 다시 시도해주세요.");
+                });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 작업 목표
- 장비 종류별 대여 가능 개수를 확인할 수 있는 equipment-list 페이지의 초기 레이아웃 및 동적 UI 구성 추가
- 관리자 페이지에서 장비를 추가하면, 해당 데이터가 API를 통해 실시간으로 리스트에 반영되는 구조 구현

## 주요 변경 사항
- equipment-list.html 페이지 추가 및 기본 UI 구조 작성
- 각 장비 카드 UI 구성: 이미지, 장비 이름, 대여 가능 개수 표시
- /api/equipments/summary API와 연동하여 장비 리스트를 동적으로 렌더링
- 카드 스타일을 위한 인라인 CSS 및 HUFS_B 폰트 적용

## 참고사항
- 장비를 추가하면 리스트가 추가되는지 확인 필요


